### PR TITLE
fix: daisyui 에서 dark-mode 를 off 로 설정

### DIFF
--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -12,5 +12,8 @@ module.exports = {
       },
     },
   },
+  daisyui: {
+    themes: ["light"],
+  },
   plugins: [require('daisyui'), require('tailwindcss-animated')],
 };


### PR DESCRIPTION
close #118 

### Test
#### safari developer tool / White mode
![image](https://github.com/2P3S/2p3s-scrum-dice/assets/52916934/192f3c00-9273-4304-a64d-51b807261d3b)

#### safari developer tool / Dark mode
![image](https://github.com/2P3S/2p3s-scrum-dice/assets/52916934/acac0298-ec2b-45ff-9a87-2f96b96e3f63)
